### PR TITLE
Rename find-package(kodi) to Kodi and get addon.xml inline with other add-ons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 
 include_directories(${KODI_INCLUDE_DIR})
 

--- a/screensaver.stars/addon.xml.in
+++ b/screensaver.stars/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.stars"
-  version="1.0.0"
+  version="1.1.0"
   name="Stars"
   provider-name="spiff">
   <requires>

--- a/screensaver.stars/addon.xml.in
+++ b/screensaver.stars/addon.xml.in
@@ -9,12 +9,10 @@
   </requires>
   <extension
     point="xbmc.ui.screensaver"
-    library_linux="screensaver.stars.so"
-    library_windx="screensaver.stars.dll"
-    library_osx="screensaver.stars.dylib"/>
+    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <summary>Stars screensaver</summary>
     <description>Stars screensaver</description>
-    <platform>linux osx windx</platform>
+    <platform>@PLATFORM@</platform>
   </extension>
 </addon>


### PR DESCRIPTION
Package renaming is need after https://github.com/xbmc/xbmc/pull/9750 goes in.
The rest is to bring xml files up to par.