### PR TITLE
remove not needed 'GetInfo(...)' call

### DIFF
--- a/screensaver.stars/addon.xml.in
+++ b/screensaver.stars/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.stars"
-  version="1.1.0"
+  version="1.2.0"
   name="Stars"
   provider-name="spiff">
   <requires>

--- a/src/Stars.cpp
+++ b/src/Stars.cpp
@@ -142,7 +142,3 @@ void ADDON_FreeSettings()
 void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
 {
 }
-
-void GetInfo(SCR_INFO *info)
-{
-}


### PR DESCRIPTION
Remove of never used `GetInfo` function.

Related to https://github.com/xbmc/xbmc/pull/11190